### PR TITLE
Simply and modernize the Capistrano configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ops"]
-	path = ops
-	url = git@github.com:nordsoftware/ops.git

--- a/Capfile
+++ b/Capfile
@@ -1,9 +1,8 @@
-set :deploy_config_path, 'ops/capistrano/deploy.rb'
-set :stage_config_path, 'ops/capistrano/deploy'
+set :deploy_config_path, 'cap/deploy.rb'
+set :stage_config_path, 'cap/deploy'
 
 require 'capistrano/setup'
 require 'capistrano/deploy'
-require 'capistrano/git-submodule-strategy'
+require 'capistrano/scm/git'
 
-# import tasks from the ops submodule
-Dir.glob('ops/capistrano/tasks/*.rake').each { |r| import r }
+install_plugin Capistrano::SCM::Git

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ On Linux `npm rebuild node-sass` might be necessary.
 * Install Capistrano by running the following commands:
 
 ```
-gem install capistrano -v '~> 3.6.0'
-gem install capistrano-git-submodule-strategy
+gem install capistrano
 ```
 
-* Place the `outdoors-sports-map` private SSH key in the `ops/packer/ansible/keys` directory. Ask your coworkers if you 
+* Place the `outdoors-sports-map` private SSH key in the `cap/keys` directory. Ask your coworkers if you 
 don't have the file.
 * Run `cap production deploy` from the project's root directory
 

--- a/cap/deploy.rb
+++ b/cap/deploy.rb
@@ -1,0 +1,37 @@
+lock '>=3.7.0'
+
+set :application, 'outdoors-sports-map'
+set :repo_url, 'git@github.com:digiaonline/outdoors-sports-map.git'
+set :deploy_to, '/home/outdoors-sports-map/outdoors-sports-map'
+set :branch, ENV["REVISION"] || ENV["BRANCH"] || "master"
+set :log_level, :info
+set :keep_releases, 5
+
+namespace :ui do
+
+	desc "Install dependencies"
+	task :install do
+		on roles(:ui) do
+			within release_path do
+				execute :yarn, "install"
+			end
+		end
+	end
+
+	desc "Build client"
+	task :build do
+		on roles(:ui) do
+			within release_path do
+				execute :npm, "run build"
+			end
+		end
+	end
+
+end
+
+namespace :deploy do
+
+  after :updated, "ui:install"
+	after :updated, "ui:build"
+
+end

--- a/cap/deploy/production.rb
+++ b/cap/deploy/production.rb
@@ -1,0 +1,7 @@
+server 'ulkoliikunta.fi', user: 'outdoors-sports-map', roles: %w{ui}, name: "outdoors-sports-map-production"
+
+set :ssh_options, {
+  keys: %w(../keys/outdoors-sports-map),
+  forward_agent: true,
+  auth_methods: %w(publickey)
+}

--- a/cap/keys/.gitignore
+++ b/cap/keys/.gitignore
@@ -1,0 +1,1 @@
+outdoors-sports-map


### PR DESCRIPTION
* the git submodule is gone which makes things easier
* the setup works with the latest version of Capistrano, no need to install a specific version of the gem